### PR TITLE
Fixes open and logging errors, adds keepalive option, missing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,49 @@ Default value: `c:/program files/iis express/iisexpress.exe`
 
 A string value that specifies the location of the IIS Express executable.
 
+#### options.keepalive
+Type: `Boolean`  
+Default value: `false`
+
+Keep the server alive until Grunt is terminated (via `ctrl+c` for example). Note that if this option is enabled, any tasks specified after this task will *never run*. By default, once Grunt tasks have completed, the web server stops. This option changes that behavior.
+
+This option can also be enabled ad-hoc by running the task like `grunt iisexpress:targetname:keepalive`.
+
+#### options.killOnExit
+Type: `Boolean`  
+Default value: `true`
+
+Kills IIS Express process after Grunt tasks have completed. Enabled by default. If you want to keep IIS Express server running after Grunt tasks have completed, set to `false`.
+
 #### options.killOn
 Type: `String`  
 Default value: `''`
 
-A string value that is used to determine when the IIS Express process should be killed. The IIS Express process will not automatically terminate when Grunt exits. This may be your desired behavior. If, however, you *do* want the IIS Express process to terminate, you will have to specify the name of an event for it to trigger the process kill.
+A string value that is used to determine when the IIS Express process should be killed. By default IIS Express process will be killed when Grunt exits (if not disabled by `killOnExit` option set to `false`). Here you can specify the name of an event to trigger IIS Express process kill when you need it.
+
+#### options.open
+Type: `Boolean`  
+Default value: `false`
+
+If set to `true`, requested URL will be opened in the browser after IIS Express server is started. Entire URL to open can be specified using `openUrl` option or it will be `'http://localhost:{port}{openPath}'`, where `port` and `openPath` are another options. By default is `false`.
+
+#### options.openPath
+Type: `String`  
+Default value: `'/'`
+
+The path part of the URL to be opened in the browser. Will not work without `open` option set to `true`.
+
+#### options.openUrl
+Type: `String`  
+Default value: `null`
+
+The URL to be opened in the browser after IIS Express server is started. Will not work without `open` option set to `true`.
+
+#### options.verbose
+Type: `Boolean`  
+Default value: `false`
+
+Enable verbose output, both for Grunt task and IIS Express. Disabled by default.
 
 ### IIS Express Options
 
@@ -128,7 +166,7 @@ grunt.initConfig({
 ```
 
 #### Killing IIS Express
-The IIS Express process will not automatically terminate when Grunt exits. This may be your desired behavior. If, however, you *do* want the IIS Express process to terminate, you will have to specify the name of an event to trigger the process kill.
+By default IIS Express process will be killed when Grunt exits (if not disabled by `killOnExit` option set to `false`). You can also specify the name of an event to trigger IIS Express process kill when you need it.
 
 You may be able to listen to an event emitted by another Grunt plugin that you are using. For example, to kill IIS Express after running [grunt-contrib-qunit](https://github.com/gruntjs/grunt-contrib-qunit/) tests:
 

--- a/tasks/iisexpress.js
+++ b/tasks/iisexpress.js
@@ -62,7 +62,9 @@ module.exports = function(grunt) {
 				grunt.fail.fatal('Must specify port or openUrl when open==true');
 			}
 			var url = options.openUrl || 'http://localhost:' + options.port + options.openPath;
-			grunt.log.writeln('opening', url);
+			if (options.verbose) {
+				grunt.log.writeln('opening', url);
+			}
 
 			var done = this.async();
 			require('open')(url, function() {

--- a/tasks/iisexpress.js
+++ b/tasks/iisexpress.js
@@ -59,7 +59,11 @@ module.exports = function(grunt) {
 			}
 			var url = options.openUrl || 'http://localhost:' + options.port + options.openPath;
 			grunt.log.writeln('opening', url);
-			require('open')(url);
+
+			var done = this.async();
+			require('open')(url, function() {
+				done();
+			});
 		}
 
 		if (options.killOn !== '') {

--- a/tasks/iisexpress.js
+++ b/tasks/iisexpress.js
@@ -5,6 +5,7 @@ module.exports = function(grunt) {
 		var _ = grunt.util._;
 		var options = this.options({
 			cmd: 'c:/program files/iis express/iisexpress.exe',
+			keepalive: false,
 			killOn: '',
 			killOnExit: true,
 			open: false,
@@ -14,6 +15,9 @@ module.exports = function(grunt) {
 		});
 		var killed = false;
 
+		// keepalive can be an option or a flag (eg 'iisexpress:dist:keepalive')
+		var keepAlive = this.flags.keepalive || options.keepalive;
+
 		// If no entry point defined: run in the current dir
 		if (options.config === undefined && options.site === undefined &&
 			options.siteid === undefined && options.path === undefined) {
@@ -21,7 +25,7 @@ module.exports = function(grunt) {
 		}
 
 		// Convert options to command line parameter format
-		var args = _.map(_.pairs(_.omit(options, ['cmd', 'killOn', 'killOnExit', 'open', 'openPath', 'openUrl', 'verbose'])), function(option) {
+		var args = _.map(_.pairs(_.omit(options, ['cmd', 'keepalive', 'killOn', 'killOnExit', 'open', 'openPath', 'openUrl', 'verbose'])), function(option) {
 			if (option[0] == 'path') {
 				option[1] = require('path').resolve(option[1]);
 			}
@@ -62,8 +66,17 @@ module.exports = function(grunt) {
 
 			var done = this.async();
 			require('open')(url, function() {
-				done();
+				if (!keepAlive) {
+					done();
+				} else {
+					grunt.log.writeln('Waiting forever...');
+				}
 			});
+		}
+
+		if (keepAlive && !done) {
+			var waitForever = this.async(); // grunt will not finish the task
+			grunt.log.writeln('Waiting forever...');
 		}
 
 		if (options.killOn !== '') {

--- a/tasks/iisexpress.js
+++ b/tasks/iisexpress.js
@@ -43,12 +43,12 @@ module.exports = function(grunt) {
 
 		if (options.verbose===true) {
 			spawn.stdout.on('data', function (data) {
-				grunt.log.write(data);
+				grunt.log.write(data.toString());
 			});
 		}
 
 		spawn.stderr.on('data', function (data) {
-			grunt.warn(data);
+			grunt.warn(data.toString());
 		});
 
 		grunt.log.ok('Started IIS Express.');


### PR DESCRIPTION
See changes in commits.

There are several fixes to exising code and new `keepalive` option (like in [grunt-contrib-connect](https://github.com/gruntjs/grunt-contrib-connect)). The option is useful to keep IIS Express working until Grunt exits, but not afterwards (comparing to `killOnExit: false` that keeps IIS Express process running). Also available as a flag, eg `iisexpress:targetname:keepalive`.

Default behavior (don't `keepalive`, but `killOnExit`) is useful for livereload, or generally to run next Grunt tasks in the pipeline. And you usually do `keepalive` when just serving something (and there are no blocking tasks further like `watch` for example).

I also updated readme to sync it with current option set and web server lifetime changes.
