### PR TITLE
Explain how to use x86 (32-bit) version of IIS Express

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Default value: `c:/program files/iis express/iisexpress.exe`
 
 A string value that specifies the location of the IIS Express executable.
 
+The default path uses the x64 (64-bit) version of IIS Express. If you need to use the x86 (32-bit) version, for instance to mimic the default Azure Websites configuration, use `C:/Program Files (x86)/IIS Express/iisexpress.exe` instead.
+
 #### options.keepalive
 Type: `Boolean`  
 Default value: `false`


### PR DESCRIPTION
I use grunt-iisexpress with Protractor to do E2E tests for a Azure Websites deployment. Because of an explicit 32-bit dependency in the project, the host process needs to be 32-bit as well. Therefore, IIS Express needs to be 32-bit. This update to `README.md` explains how to do it.
