### PR TITLE
Add option to wait until IIS express is running before completing task

### DIFF
--- a/tasks/iisexpress.js
+++ b/tasks/iisexpress.js
@@ -11,7 +11,8 @@ module.exports = function(grunt) {
 			open: false,
 			openPath: '/',
 			openUrl: null,
-			verbose: false
+			verbose: false,
+			waitUntilStarted: false
 		});
 		var killed = false;
 
@@ -25,7 +26,7 @@ module.exports = function(grunt) {
 		}
 
 		// Convert options to command line parameter format
-		var args = _.map(_.pairs(_.omit(options, ['cmd', 'keepalive', 'killOn', 'killOnExit', 'open', 'openPath', 'openUrl', 'verbose'])), function(option) {
+		var args = _.map(_.pairs(_.omit(options, ['cmd', 'keepalive', 'killOn', 'killOnExit', 'open', 'openPath', 'openUrl', 'verbose', 'waitUntilStarted'])), function(option) {
 			if (option[0] == 'path') {
 				option[1] = require('path').resolve(option[1]);
 			}
@@ -55,7 +56,19 @@ module.exports = function(grunt) {
 			grunt.warn(data.toString());
 		});
 
-		grunt.log.ok('Started IIS Express.');
+		if (options.waitUntilStarted) {
+			grunt.log.writeln('Waiting until IIS Express is running')
+
+			var done = this.async();
+			spawn.stdout.on('data', function (data) {
+				if (data.toString().indexOf('IIS Express is running.') !== -1) {
+					grunt.log.ok('Started IIS Express.');
+					done();
+				}
+			});
+		} else {
+			grunt.log.ok('Started IIS Express.');
+		}
 
 		if (options.open===true) {
 			if (!options.port && !options.openUrl) {


### PR DESCRIPTION
Currently the task will not wait until IIS Express has successfully started before completing.

If IIS Express fails to start and writes to stderr, then there will be an uncaught exception in the grunt process.

For example, we use protractor and protractor's process.on('uncaughtException') handler will pick it up and it will be reported as part of running the protractor task, even though it was actually really part of the grunt-iisexpress task.